### PR TITLE
fix: Resolve developer keepalive failures with resilient 2FA verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ screenshots/
 stats-*.html
 screenshot-*.png
 developer-*.png
+developer-summary.json
+stats-summary.json
 
 # Temporary files
 tmp/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-pdi-monitor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ServiceNow PDI monitoring and developer account keepalive using GitHub Actions and Puppeteer",
   "main": "src/scrape-stats.js",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR resolves intermittent failures in the Developer Account Keepalive GitHub Actions workflow by implementing robust error handling for 2FA verification and page navigation edge cases.

**Key improvements:**
- Added resilient `checkStillOn2FA` helper that gracefully handles "Execution context was destroyed" errors during 2FA verification
- Fixed false negative failures where successful logins were incorrectly marked as failures due to race conditions during page redirects
- Added detection and wait logic for `login_redirect.do` redirect pages to prevent `ERR_ABORTED` navigation errors
- Enhanced error handling for `page.evaluate()` calls during navigation transitions
- Added 10-second delays between account processing to avoid rate limiting
- Fixed URL inconsistencies in debug version (8 locations where both `developer.servicenow.com` and `developers.servicenow.com` needed to be checked)
- Added `developer-summary.json` and `stats-summary.json` to `.gitignore` to prevent dirty repository state after local test runs

## Testing

✅ All 3 configured developer accounts tested successfully (3/3 success rate)
- Test command: `SKIP_SCREENSHOTS=true DEVELOPER_ACCOUNTS_JSON="$(cat accounts.json)" node src/developer-login.js`
- All accounts completed login → 2FA → instance navigation successfully
- No false negative failures observed

## Changes

- **Version**: Bumped from `1.1.0` → `1.1.1` (patch fix)
- **Files modified**: 4 files, 219 insertions, 58 deletions
  - `.gitignore` - Added test artifact files
  - `package.json` - Version bump
  - `src/developer-login.js` - Production fixes
  - `src/developer-login-debug.js` - Debug version fixes

## Technical Details

The critical bug was in the 2FA verification logic. After successful 2FA submission, the page immediately redirects, causing `page.evaluate()` to throw "Execution context was destroyed". The original code didn't handle this, treating successful navigations as failures.

The new `checkStillOn2FA` helper implements retry logic that treats repeated context destruction as a success signal (the page is navigating away), while still catching actual 2FA failures where incorrect TOTP codes keep the user on the 2FA page.

## Related Issues

Fixes the intermittent GitHub Actions failures shown in the Developer Account Keepalive workflow.